### PR TITLE
fix: install darkdraw even if vd>=2.9 is unsatisfiable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-alpine
 RUN pip install requests python-dateutil wcwidth
 
 RUN apk add git
-RUN pip install git+https://github.com/devottys/darkdraw.git
+RUN pip install git+https://github.com/devottys/darkdraw.git --no-deps
 RUN pip install --upgrade git+https://github.com/saulpw/visidata.git@develop
 RUN sh -c "echo >>~/.visidatarc import darkdraw"
 RUN git clone https://github.com/devottys/studio


### PR DESCRIPTION
Tried to build this locally and hit an error because `pip` tries to
resolve the (I think) unreleased dev version.  But since it gets
installed on the next line of the dockerfile anyway, it seems safe to
skip the dependency resolution.
