### PR TITLE
[ansihtml-] load maxX and maxY for Drawing before saving

### DIFF
--- a/darkdraw/ansihtml.py
+++ b/darkdraw/ansihtml.py
@@ -96,6 +96,7 @@ def save_ansihtml(vd, p, *sheets):
 
         dwg._scr = mock.MagicMock(__bool__=mock.Mock(return_value=True),
                                   getmaxyx=mock.Mock(return_value=(9999, 9999)))
+        dwg.reload()
         dwg.draw(dwg._scr)
         body = '''<pre>'''
         for y in range(dwg.minY, dwg.maxY+1):


### PR DESCRIPTION
Since we are instantiating a fresh `Drawing()` object, we need to make sure it had done its `reload`. The `reload` is where `maxX` and `maxY` are set.

This fixes saving `.ansihtml` during a session.