### PR TITLE
Dur2ddw

### DIFF
--- a/dur2ddw.py
+++ b/dur2ddw.py
@@ -33,14 +33,14 @@ durdraw_color16_fg_map = {
 
 durdraw_color16_bg_map = {
         0: -1, #??
-    1: 4, # black
-    2: 2, # blue
-    3: 6, # green
-    4: 1, # cyan
-    5: 5, # red
-    6: 3, # magenta
-    7: 7, # yellow
-    8: 0, # light grey
+    1: 4, # blue
+    2: 2, # green
+    3: 6, # cyan
+    4: 1, # red
+    5: 5, # magenta
+    6: 3, # yellow
+    7: 7, # light grey
+    8: 0, # black
 }
 
 def convert_dur_to_ddw(infn, outfp):
@@ -63,6 +63,8 @@ def convert_dur_to_ddw(infn, outfp):
                 fg, bg = colors[x][y]
                 fg = durdraw_color16_fg_map[fg]
                 bg = durdraw_color16_bg_map[bg]
+                if ch == ' ' and bg == 0:
+                    continue
                 d = dict(x=x,
                          y=y,
                          text=ch,

--- a/dur2ddw.py
+++ b/dur2ddw.py
@@ -11,26 +11,37 @@ import sys
 import json
 import gzip
 
-durdraw_color16_map = {
-    0: -1, #??
-    1: 0,
+durdraw_color16_fg_map = {
+        0: -1, #??
+    1: 0, # black
     2: 4, # blue
     3: 2, # green
     4: 6, # cyan
     5: 1, # red
     6: 5, # magenta
     7: 3, # yellow
-    8: 7,
-    9: 0,
+    8: 7, # light grey
+    9: 8, # dark grey
     10: 12, # bright blue
     11: 10, # bright green
     12: 14, # bright cyan
     13: 9, # bright red
     14: 13, # bright magenta
     15: 11, # bright yellow
-    16: 15,
+    16: 15, # white
 }
 
+durdraw_color16_bg_map = {
+        0: -1, #??
+    1: 4, # black
+    2: 2, # blue
+    3: 6, # green
+    4: 1, # cyan
+    5: 5, # red
+    6: 3, # magenta
+    7: 7, # yellow
+    8: 0, # light grey
+}
 
 def convert_dur_to_ddw(infn, outfp):
     dur = json.loads(gzip.open(infn).read())
@@ -49,11 +60,9 @@ def convert_dur_to_ddw(infn, outfp):
 
         for y, line in enumerate(lines):
             for x, ch in enumerate(line):
-                if ch == ' ':
-                    continue
                 fg, bg = colors[x][y]
-                fg = durdraw_color16_map[fg]
-                bg = durdraw_color16_map[bg]
+                fg = durdraw_color16_fg_map[fg]
+                bg = durdraw_color16_bg_map[bg]
                 d = dict(x=x,
                          y=y,
                          text=ch,

--- a/dur2ddw.py
+++ b/dur2ddw.py
@@ -12,7 +12,7 @@ import json
 import gzip
 
 durdraw_color16_fg_map = {
-        0: -1, #??
+    0: -1, #??
     1: 0, # black
     2: 4, # blue
     3: 2, # green
@@ -32,7 +32,7 @@ durdraw_color16_fg_map = {
 }
 
 durdraw_color16_bg_map = {
-        0: -1, #??
+    0: -1, #??
     1: 4, # blue
     2: 2, # green
     3: 6, # cyan
@@ -50,11 +50,15 @@ def convert_dur_to_ddw(infn, outfp):
         n = f['frameNumber']
         lines = f['contents']
         colors = f['colorMap']
+        if f['delay'] == 0: ### if delay is not specified, find duration based on animation framerate
+            duration_ms = int(1000 // dur['DurMovie']['framerate'])
+        else: ### if specified, convert to ms
+            duration_ms = int(f['delay'] * 1000)
 
         d = dict(
             id=str(n),
             type='frame',
-            duration_ms=f['delay']
+            duration_ms=duration_ms
         )
         print(json.dumps(d), file=outfp)
 


### PR DESCRIPTION
Converted frame timing format so that output .ddw should play without crashing in DarkDraw at the same speed that the input .dur plays in DurDraw. Also tidied up the indentation of the color maps.