### PR TITLE
itemized paste mode fix

### DIFF
--- a/darkdraw/drawing.py
+++ b/darkdraw/drawing.py
@@ -712,11 +712,13 @@ class Drawing(TextCanvas):
             while newx < box.x1+box.w and niters < 10000:
                 niters += 1
                 oldr = next(it)
-                if self.paste_mode in 'all char':
+                if self.paste_mode in ('all', 'char'):
                     r = self.newRow()
                     r.update(deepcopy(oldr))
                     r.x, r.y = newx, newy
                     r.text = oldr.text
+                    if self.paste_mode == 'char':
+                        r.color = vd.default_color
                     newrows.append(r)
                     nfilled += 1
                     self.source.addRow(r)


### PR DESCRIPTION
-modified `place_text` to include color if provided or use default color otherwise
-modified `paste-char-n` commands to respect paste mode

The itemized pasting does not respect paste mode in the previous commit. This restores that functionality.

This has the side effect of using default color for text entered directly onto the canvas (`a` or `e`), which was unintentional but which feels more intuitive and practical to me, as the user can set default color to white if desired, but with the original behavior, text entered into the canvas was always white, and assigning a different color had to be done with a separate operation.

~~I could not seem to get this to work with the `paste-char-n` command on a single line to keep the formatting consistent.~~