### PR TITLE
fix/64 paste undo

### DIFF
--- a/darkdraw/drawing.py
+++ b/darkdraw/drawing.py
@@ -706,7 +706,9 @@ class Drawing(TextCanvas):
                 if oldr.color and newx < box.x2 and newy < box.y2-1:
                     for existing in self._displayedRows[(newx, newy)][-(n or 0):]:
                         npasted += 1
+                        oldcolor = existing.color
                         existing.color = oldr.color
+                        vd.addUndo(setattr, existing, 'color', oldcolor)
 
         if npasted == 0:
             vd.warning(f'paste mode {self.paste_mode} had nothing to paste')

--- a/darkdraw/drawing.py
+++ b/darkdraw/drawing.py
@@ -474,11 +474,12 @@ class Drawing(TextCanvas):
             self.set_color(vd.current_charset[n].color, self.cursorRows)
             return
 
-        color = None
-        if self.paste_mode != "char":
-            color = vd.current_charset[n].color
-
-        self.place_text(vd.current_charset[n].text, box, color=color)
+        text = vd.current_charset[n].text
+        if self.paste_mode == "char":
+            self.place_text(text, box)
+        else:  # 'all' - preserve source color even when empty (do not coerce to default_color)
+            self.add_text(text, box.x1, box.y1, vd.current_charset[n].color)
+            self.go_forward(dispwidth(text), 1)
 
     def edit_text(self, text, row):
         if row is None:


### PR DESCRIPTION
- **[paste] paste-char-n in 'all' mode preserves empty source color (#64)**
- **[paste] make color-mode paste undoable (#64)**
