### PR TITLE
minimize redundant autosaves

### DIFF
--- a/darkdraw/drawing.py
+++ b/darkdraw/drawing.py
@@ -94,6 +94,14 @@ class DrawingSheet(JsonSheet):
     colorizers = [
         CellColorizer(3, None, lambda s,c,r,v: r and c and c.name == 'text' and r.color)
     ]
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.autosaved = True
+
+    def setModified(self):
+        super().setModified()
+        self.autosaved = False
+
     def newRow(self):
         return AttrDict(x=None, y=None, text='', color='', tags='', group='')
 
@@ -308,10 +316,12 @@ class Drawing(TextCanvas):
             now = time.time()
             autosave_interval_s = self.options.autosave_interval_s
             if autosave_interval_s and now-self.last_autosave > autosave_interval_s:
-                p = Path(options.autosave_path)
-                if not p.exists():
-                    os.makedirs(p)
-                vd.saveSheets(p/time.strftime(self.name+'-%Y%m%dT%H%M%S.ddw', time.localtime(now)), self, confirm_overwrite=False)
+                if not self.source.autosaved:
+                    p = Path(options.autosave_path)
+                    if not p.exists():
+                        os.makedirs(p)
+                    vd.saveSheets(p/time.strftime(self.name+'-%Y%m%dT%H%M%S.ddw', time.localtime(now)), self, confirm_overwrite=False)
+                    self.source.autosaved = True
                 self.last_autosave = now
         except Exception as e:
             vd.exceptionCaught(e)
@@ -441,6 +451,7 @@ class Drawing(TextCanvas):
     def reload(self):
         self.source.ensureLoaded()
         vd.sync()
+        self.source.autosaved = True
         if self._scr:
             self.draw(self._scr)
 
@@ -822,7 +833,7 @@ Drawing.init('disabled_tags', set)  # set of groupnames which should not be draw
 
 Drawing.init('mark', lambda: (0,0))
 Drawing.init('paste_mode', lambda: 'all')
-Drawing.init('last_autosave', int)
+Drawing.init('last_autosave', time.time)
 
 # (xoffset, yoffset) is absolute coordinate of upper left of viewport (0, 0)
 Drawing.init('yoffset', int)


### PR DESCRIPTION
  - DrawingSheet.__init__: adds self.autosaved=True (line 97-99)
  - DrawingSheet.setModified: flips autosaved=False (line 101-103)
  - Drawing.autosave: skips save when source.autosaved already True; sets True after save (line 319-324)
  - Drawing.reload: clears source.autosaved=True post-load to discard load-induced dirty flag (line 454)
  - last_autosave init: int → time.time so open-time anchors interval check (line 835)

+claude

Current behavior is for drawings to autosave immediately on opening and again at every autosave interval, whether or not edits have been made. With a short interval and/or a session left open for a long time, the autosave dir can quickly become unwieldy, and any specific point in the history can be a needle in a haystack. These changes prevent autosave from firing until an edit has been made AND at least one autosave interval has elapsed since load or the last autosave.